### PR TITLE
Fix error message for failed object conversion

### DIFF
--- a/ocp_tessellate/convert.py
+++ b/ocp_tessellate/convert.py
@@ -300,7 +300,7 @@ def conv(cad_obj, obj_name=None, obj_color=None, obj_alpha=1.0):
         cad_objs = [downcast(cad_obj)]
 
     else:
-        raise RuntimeError(f"Cannot transform {cad_objs}({type(cad_objs)}) to OCP")
+        raise RuntimeError(f"Cannot transform {cad_obj}({type(cad_obj)}) to OCP")
 
     if is_compound_list(cad_objs):
         cad_objs = get_downcasted_shape(cad_objs[0])


### PR DESCRIPTION
The original `cad_objs` will just log an empty list. Assuming the original intent was to log `cad_obj` instead. 

Noticed this while exploring voneiden/cq-cam/issues/23 

As a side note, looks like adding support for AIS objects might be a bit involved. We got two visualization options in cq-cam, AIS based and Edge based. AIS was originally used because it allows connecting lines of different colours using AIS_MultipleConnectedInteractive. However I'd be willing to research a bit if the edge based visualization can be improved to make AIS visualization redundant.