### PR TITLE
fix get_location

### DIFF
--- a/ocp_tessellate/ocp_utils.py
+++ b/ocp_tessellate/ocp_utils.py
@@ -929,6 +929,8 @@ def get_location(obj, as_none=True):
             loc = obj.loc
         elif hasattr(obj, "location"):
             loc = obj.location
+            if callable(loc):
+                loc = loc()
         elif isinstance(obj, TopLoc_Location):
             return obj
         else:


### PR DESCRIPTION
I noticed that the threads example from https://github.com/gumyr/cq_warehouse/ fails with the following error:

```
  File "/Users/dorianrudolph/mambaforge/envs/cad/lib/python3.11/site-packages/ocp_tessellate/ocp_utils.py", line 942, in get_location
    raise TypeError(f"Unknown location typ {type(loc)}")
TypeError: Unknown location typ <class 'method'>
```

It seems like `location` can either be a property (Plane) or a function (Solid).