### PR TITLE
fix: add get_curve and  get_surface

### DIFF
--- a/ocp_tessellate/ocp_utils.py
+++ b/ocp_tessellate/ocp_utils.py
@@ -492,6 +492,14 @@ def get_downcasted_shape(shape):
     return [downcast(obj) for obj in objs]
 
 
+def get_curve(edge):
+    return BRepAdaptor_Curve(edge).Curve()
+
+
+def get_surface(face):
+    return BRepAdaptor_Surface(face).Surface()
+
+
 def get_point(vertex):
     p = BRep_Tool.Pnt_s(vertex)
     return (p.X(), p.Y(), p.Z())


### PR DESCRIPTION
This PR simply adds `get_curve` and `get_surface` to resolve an issue when starting the [OCP backend terminal in vscode-ocp-cad-viewer on v2.6.0](https://github.com/bernhard-42/vscode-ocp-cad-viewer/blob/55f33bb5b40faf66940391acf388a0bc7eaa1829/src/controller.ts#L246)