### PR TITLE
fix typo in `tessellator.py`

### DIFF
--- a/ocp_tessellate/tessellator.py
+++ b/ocp_tessellate/tessellator.py
@@ -276,7 +276,7 @@ class Tessellator:
                         if n_buf.SquareMagnitude() > 0:
                             n_buf.Normalize()
                         flat.extend(
-                            n_buf.Reverse().Coord() if internal else n_buf.Coord()
+                            n_buf.Reversed().Coord() if internal else n_buf.Coord()
                         )
                     self.normals.extend(flat)
 


### PR DESCRIPTION
`.Reverse()` reverses in place and return `None`, needs `.Reversed()` instead.

Not sure how where/how the test should go but here's an example of how to hit that part of the code with `build123d`

```py
box = Box(10, 10, 10)
rect = Rectangle(12, 12, align=(Align.MIN, Align.CENTER))
partially_split_box = box.split(rect)
show(partially_split_box)
```