### PR TITLE
Small optimization for hash_compat

### DIFF
--- a/ocp_tessellate/ocp_utils.py
+++ b/ocp_tessellate/ocp_utils.py
@@ -106,13 +106,12 @@ def occt_version():
 # %% OCP Helpers
 #
 
-
-def hash_compat(obj):
-    if OCP.__version__.startswith("7.7"):
+if OCP.__version__.startswith("7.7"):
+    def hash_compat(obj):
         MAX_HASH_KEY = 2147483647
         return obj.HashCode(MAX_HASH_KEY)
-    else:
-        return hash(obj)
+else:
+    hash_compat = hash
 
 
 def ocp_hash(obj):


### PR DESCRIPTION
A small optimization for hash_compat:
Instead of checking OCCT version on each call, define the function based on OCCT version.