### PR TITLE
Fix exporting super simple STEP imports to build123d.

### DIFF
--- a/ocp_tessellate/stepreader.py
+++ b/ocp_tessellate/stepreader.py
@@ -349,9 +349,12 @@ class StepReader:
 
         if len(self.assemblies) == 1:
             assembly = self.assemblies[0]
-            return walk(
-                assembly["shapes"], assembly["name"], cq.Location(assembly["loc"])
-            )
+            if assembly["shapes"] is not None:
+                return walk(assembly["shapes"], assembly["name"], cq.Location(assembly["loc"]))
+            elif assembly["shape"] is not None:
+                return walk([assembly], assembly["name"], cq.Location(assembly["loc"]))
+            else:
+                raise ValueError("No shapes in the first asssembly")
         else:
             result = cq.Assembly(name="Group")
             for assembly in self.assemblies:


### PR DESCRIPTION
I encountered an issue recently when trying to use super simple STEP files imported into build123d, such as the one attached.

[super-simple-steps.zip](https://github.com/user-attachments/files/18631579/super-simple-steps.zip)

This was the error:

```
Traceback (most recent call last):
  File "/workspaces/zaphod-pro/case.py", line 479, in <module>
    molex = load_step("3dmodels/781710004.stp")
  File "/workspaces/zaphod-pro/case.py", line 453, in load_step
    return r.to_build123d()
  File "/root/.local/lib/python3.10/site-packages/ocp_tessellate/stepreader.py", line 415, in to_build123d
    return walk(assembly["shapes"], assembly["name"], Location(assembly["loc"]))
  File "/root/.local/lib/python3.10/site-packages/ocp_tessellate/stepreader.py", line 380, in walk
    for obj in objs:
TypeError: 'NoneType' object is not iterable
```

The attached change fixes loading for me.

Thanks!